### PR TITLE
Adding RUNID in EvaluationQueryOutput

### DIFF
--- a/CS-GenerateQueries-MASTER.pl
+++ b/CS-GenerateQueries-MASTER.pl
@@ -84,7 +84,7 @@ sub generate_round2_query {
 sub generate_round1_queries {
   my ($logger, $queries) = @_;
   my $new_queries = QuerySet->new($logger);
-  foreach my $query ($queries->get_all()) {
+  foreach my $query ($queries->get_all_queries()) {
     $new_queries->add(&generate_round1_query($logger, $query));
   }
   $new_queries;

--- a/CS-Score-Wrapper.pl
+++ b/CS-Score-Wrapper.pl
@@ -23,7 +23,7 @@ foreach my $run_file( @run_files ){
 	my ($run_file_dir, $run_file_name) = ($1,$2);
 	my $output_file_name = $run_file_name.".".$output_postfix;
 	my $output_file = "$runs_dir/$run_file_dir$output_file_name";
-	push(@cmds, "perl CS-Score-MASTER.pl $assessment_file $run_file $queries_file > $output_file");
+	push(@cmds, "perl CS-Score.pl $assessment_file $run_file $queries_file > $output_file");
 	#print "--running cmd=$cmd\n";
 	#`$cmd`;
 }

--- a/ColdStartLib.pm
+++ b/ColdStartLib.pm
@@ -115,6 +115,8 @@ END_PROBLEM_FORMATS
 
 package Logger;
 
+use Carp;
+
 # Create a new Logger object
 sub new {
   my ($class, $formats, $error_output) = @_;

--- a/ColdStartLib.pm
+++ b/ColdStartLib.pm
@@ -2403,6 +2403,17 @@ print STDERR "Wrong number of elements: <<", join(">> <<", @elements), ">>\n";
     # Keep track of all RUNIDs
     $self->{RUNIDS}{$entry->{RUNID}}++ if defined $entry->{RUNID};
     # FIXME: Record MULTIPLE_RUNIDS problem here?
+    
+	my $current_runid = $self->get_runid();
+    if (defined $current_runid) {
+      if (defined $entry->{RUNID} && $entry->{RUNID} ne $current_runid) {
+	    $logger->record_problem('MULTIPLE_RUNIDS', $current_runid, $entry->{RUNID}, $entry);
+	    $entry->{RUNID} = $current_runid;
+      }
+    }
+    else {
+      $self->set_runid($entry->{RUNID});
+    }
 
     # Allow recovery of parent query ID and equivalence class
     if ($entry->{TYPE} eq 'ASSESSMENT' && $entry->{JUDGMENT} eq 'CORRECT') {
@@ -2703,6 +2714,11 @@ sub tostring {
 sub get_runid {
   my ($self) = @_;
   $self->{RUNID};
+}
+
+sub set_runid {
+  my ($self, $new_runid) = @_;
+  $self->{RUNID} = $new_runid;
 }
 
 sub set_confidence {


### PR DESCRIPTION
CS-PackageOutput-MASTER.pl was complaining about missing RUNID. This fixes the problem.
